### PR TITLE
Update NuGets, Add SetCompatibilityVersion and AllowCombiningAuthorizeFilters workaround.

### DIFF
--- a/src/Host/Host.csproj
+++ b/src/Host/Host.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Host/Startup.cs
+++ b/src/Host/Startup.cs
@@ -5,6 +5,7 @@ using Host.AspNetCorePolicy;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -30,7 +31,15 @@ namespace Host
                     .RequireAuthenticatedUser()
                     .Build();
                 options.Filters.Add(new AuthorizeFilter(policy));
-            });
+
+                // Known bug in MVC 2.1 that breaks authorization policy providers
+                // This is because setting the compatibility version below to 2.1 sets `AllowCombiningAuthorizeFilters` to true, exposing a bug
+                // https://github.com/aspnet/Mvc/issues/7809
+                options.AllowCombiningAuthorizeFilters = false;
+            })
+            // Using `SetCompatibilityVersion()` is recommended for Core 2.1 and onward.
+            // https://blogs.msdn.microsoft.com/webdev/2018/02/27/introducing-compatibility-version-in-mvc/
+            .SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
 
             // this sets up authentication - for this demo we simply use a local cookie
             // typically authentication would be done using an external provider

--- a/src/PolicyServer.Local/PolicyServer.Local.csproj
+++ b/src/PolicyServer.Local/PolicyServer.Local.csproj
@@ -18,12 +18,12 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
   </ItemGroup>
 
 </Project>

--- a/test/PolicyServerLocal.Tests/PermissionTests.cs
+++ b/test/PolicyServerLocal.Tests/PermissionTests.cs
@@ -21,7 +21,7 @@ namespace PolicyServerLocal.Tests
         public void Evaluate_should_require_roles()
         {
             Action a = () => _subject.Evaluate(null);
-            a.ShouldThrow<ArgumentNullException>();
+            a.Should().Throw<ArgumentNullException>();
         }
 
         [Fact]

--- a/test/PolicyServerLocal.Tests/PolicyServerLocal.Tests.csproj
+++ b/test/PolicyServerLocal.Tests/PolicyServerLocal.Tests.csproj
@@ -1,16 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="FluentAssertions" Version="5.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/PolicyServerLocal.Tests/PolicyTests.cs
+++ b/test/PolicyServerLocal.Tests/PolicyTests.cs
@@ -22,7 +22,7 @@ namespace PolicyServerLocal.Tests
         public void Evaluate_should_require_user()
         {
             Func<Task> a = () => _subject.EvaluateAsync(null);
-            a.ShouldThrow<ArgumentNullException>();
+            a.Should().Throw<ArgumentNullException>();
         }
 
         [Fact]
@@ -38,7 +38,7 @@ namespace PolicyServerLocal.Tests
 
             var result = await _subject.EvaluateAsync(user);
 
-            result.Roles.ShouldAllBeEquivalentTo(new[] { "a", "c" });
+            result.Roles.Should().BeEquivalentTo(new[] { "a", "c" });
         }
 
         [Fact]
@@ -69,7 +69,7 @@ namespace PolicyServerLocal.Tests
 
             var result = await _subject.EvaluateAsync(user);
 
-            result.Roles.ShouldAllBeEquivalentTo(new[] { "a" });
+            result.Roles.Should().BeEquivalentTo(new[] { "a" });
         }
 
         [Fact]
@@ -89,7 +89,7 @@ namespace PolicyServerLocal.Tests
 
             var result = await _subject.EvaluateAsync(user);
 
-            result.Permissions.ShouldAllBeEquivalentTo(new[] { "a", "c" });
+            result.Permissions.Should().BeEquivalentTo(new[] { "a", "c" });
         }
 
         [Fact]
@@ -126,7 +126,7 @@ namespace PolicyServerLocal.Tests
 
             var result = await _subject.EvaluateAsync(user);
 
-            result.Permissions.ShouldAllBeEquivalentTo(new[] { "a" });
+            result.Permissions.Should().BeEquivalentTo(new[] { "a" });
         }
 
         [Fact]

--- a/test/PolicyServerLocal.Tests/RoleTests.cs
+++ b/test/PolicyServerLocal.Tests/RoleTests.cs
@@ -21,7 +21,7 @@ namespace PolicyServerLocal.Tests
         public void Evaluate_should_require_user()
         {
             Action a = ()=>_subject.Evaluate(null);
-            a.ShouldThrow<ArgumentNullException>();
+            a.Should().Throw<ArgumentNullException>();
         }
 
         [Fact]


### PR DESCRIPTION
Ref https://github.com/PolicyServer/PolicyServer.Local/issues/12
Ref https://github.com/aspnet/Mvc/issues/7809

As discussed and recommended by @leastprivilege at this [comment](https://github.com/PolicyServer/PolicyServer.Local/issues/12#issuecomment-407645684) I have added `options.AllowCombiningAuthorizeFilters = false;` and a descriptive comment.

This is important because I spent quite some time googling only to stumble upon the original issue at MVC and find a fix. As [this blog post](https://blogs.msdn.microsoft.com/webdev/2018/02/27/introducing-compatibility-version-in-mvc/) says, all new templates will come with `SetCompatibilityVersion(*)` set in the template. So that means that others will have good chance of stumbling into this bug. So adding the fix to the Host will be a good way to help people out until 2.2

While i was in there I also updated everything to Core 2.1, and fixed the tests because the new FluentValidations came with some breaking changes.