### PR TITLE
Update to core 3.

### DIFF
--- a/src/Host/Host.csproj
+++ b/src/Host/Host.csproj
@@ -1,13 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
-  </ItemGroup>
-
+  
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.1" />
   </ItemGroup>

--- a/src/Host/Host.csproj
+++ b/src/Host/Host.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Brock Allen, Dominick Baier, Michele Leroux Bustamante. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 
 namespace Host
 {
@@ -10,12 +10,15 @@ namespace Host
     {
         public static void Main(string[] args)
         {
-            BuildWebHost(args).Run();
+            BuildHost(args).Run();
         }
 
-        public static IWebHost BuildWebHost(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
+        public static IHost BuildHost(string[] args) =>
+            Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                })
                 .Build();
     }
 }

--- a/src/Host/Startup.cs
+++ b/src/Host/Startup.cs
@@ -5,6 +5,7 @@ using Host.AspNetCorePolicy;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -30,7 +31,15 @@ namespace Host
                     .RequireAuthenticatedUser()
                     .Build();
                 options.Filters.Add(new AuthorizeFilter(policy));
-            });
+
+                // Known bug in MVC 2.1 that breaks authorization policy providers
+                // This is because setting the compatibility version below to 2.1 sets `AllowCombiningAuthorizeFilters` to true, exposing a bug
+                // https://github.com/aspnet/Mvc/issues/7809
+                options.AllowCombiningAuthorizeFilters = false;
+            })
+            // Using `SetCompatibilityVersion()` is recommended for Core 2.1 and onward.
+            // https://blogs.msdn.microsoft.com/webdev/2018/02/27/introducing-compatibility-version-in-mvc/
+            .SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
 
             // this sets up authentication - for this demo we simply use a local cookie
             // typically authentication would be done using an external provider

--- a/src/Host/Startup.cs
+++ b/src/Host/Startup.cs
@@ -22,15 +22,9 @@ namespace Host
 
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc(options =>
-            {
-                // this sets up a default authorization policy for the application
-                // in this case, authenticated users are required (besides controllers/actions that have [AllowAnonymous]
-                var policy = new AuthorizationPolicyBuilder()
-                    .RequireAuthenticatedUser()
-                    .Build();
-                options.Filters.Add(new AuthorizeFilter(policy));
-            });
+            // `AddControllersWithViews()` Calls AddAuthorization under the hood.
+            // Below, in the call to `UseEndpoints(...)` we require authorization to all controllers (besides controllers/actions that have `[AllowAnonymous]`).
+            services.AddControllersWithViews();
 
             // this sets up authentication - for this demo we simply use a local cookie
             // typically authentication would be done using an external provider
@@ -45,10 +39,14 @@ namespace Host
             services.AddTransient<IAuthorizationHandler, MedicationRequirementHandler>();
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             app.UseDeveloperExceptionPage();
+
+            app.UseRouting();
+
             app.UseAuthentication();
+            app.UseAuthorization();
 
             // add this middleware to make roles and permissions available as claims
             // this is mainly useful for using the classic [Authorize(Roles="foo")] and IsInRole functionality
@@ -56,7 +54,11 @@ namespace Host
             app.UsePolicyServerClaims();
 
             app.UseStaticFiles();
-            app.UseMvcWithDefaultRoute();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapDefaultControllerRoute().RequireAuthorization();
+            });
         }
     }
 }

--- a/src/PolicyServer.Local/PolicyServer.Local.csproj
+++ b/src/PolicyServer.Local/PolicyServer.Local.csproj
@@ -18,12 +18,12 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
   </ItemGroup>
 
 </Project>

--- a/src/PolicyServer.Local/PolicyServer.Local.csproj
+++ b/src/PolicyServer.Local/PolicyServer.Local.csproj
@@ -1,7 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <OutputType>Library</OutputType>
     <VersionPrefix>1.0.3</VersionPrefix>
 
     <Authors>Brock Allen;Dominick Baier;Michele Leroux-Bustamante</Authors>
@@ -18,12 +19,9 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.0.0" />
   </ItemGroup>
 
 </Project>

--- a/test/PolicyServerLocal.Tests/PermissionTests.cs
+++ b/test/PolicyServerLocal.Tests/PermissionTests.cs
@@ -21,7 +21,7 @@ namespace PolicyServerLocal.Tests
         public void Evaluate_should_require_roles()
         {
             Action a = () => _subject.Evaluate(null);
-            a.ShouldThrow<ArgumentNullException>();
+            a.Should().Throw<ArgumentNullException>();
         }
 
         [Fact]

--- a/test/PolicyServerLocal.Tests/PolicyServerLocal.Tests.csproj
+++ b/test/PolicyServerLocal.Tests/PolicyServerLocal.Tests.csproj
@@ -1,16 +1,18 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/PolicyServerLocal.Tests/PolicyServerLocal.Tests.csproj
+++ b/test/PolicyServerLocal.Tests/PolicyServerLocal.Tests.csproj
@@ -1,16 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="FluentAssertions" Version="5.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/PolicyServerLocal.Tests/PolicyTests.cs
+++ b/test/PolicyServerLocal.Tests/PolicyTests.cs
@@ -22,7 +22,7 @@ namespace PolicyServerLocal.Tests
         public void Evaluate_should_require_user()
         {
             Func<Task> a = () => _subject.EvaluateAsync(null);
-            a.ShouldThrow<ArgumentNullException>();
+            a.Should().Throw<ArgumentNullException>();
         }
 
         [Fact]
@@ -38,7 +38,7 @@ namespace PolicyServerLocal.Tests
 
             var result = await _subject.EvaluateAsync(user);
 
-            result.Roles.ShouldAllBeEquivalentTo(new[] { "a", "c" });
+            result.Roles.Should().BeEquivalentTo(new[] { "a", "c" });
         }
 
         [Fact]
@@ -69,7 +69,7 @@ namespace PolicyServerLocal.Tests
 
             var result = await _subject.EvaluateAsync(user);
 
-            result.Roles.ShouldAllBeEquivalentTo(new[] { "a" });
+            result.Roles.Should().BeEquivalentTo(new[] { "a" });
         }
 
         [Fact]
@@ -89,7 +89,7 @@ namespace PolicyServerLocal.Tests
 
             var result = await _subject.EvaluateAsync(user);
 
-            result.Permissions.ShouldAllBeEquivalentTo(new[] { "a", "c" });
+            result.Permissions.Should().BeEquivalentTo(new[] { "a", "c" });
         }
 
         [Fact]
@@ -126,7 +126,7 @@ namespace PolicyServerLocal.Tests
 
             var result = await _subject.EvaluateAsync(user);
 
-            result.Permissions.ShouldAllBeEquivalentTo(new[] { "a" });
+            result.Permissions.Should().BeEquivalentTo(new[] { "a" });
         }
 
         [Fact]

--- a/test/PolicyServerLocal.Tests/RoleTests.cs
+++ b/test/PolicyServerLocal.Tests/RoleTests.cs
@@ -21,7 +21,7 @@ namespace PolicyServerLocal.Tests
         public void Evaluate_should_require_user()
         {
             Action a = ()=>_subject.Evaluate(null);
-            a.ShouldThrow<ArgumentNullException>();
+            a.Should().Throw<ArgumentNullException>();
         }
 
         [Fact]


### PR DESCRIPTION
Before rejecting this as "we don't accept PRs for this library", id like to add that this library is completely broken for Core 3.

```
    System.MissingMethodException : Method not found: 'Microsoft.Extensions.DependencyInjection.IServiceCollection
Microsoft.Extensions.DependencyInjection.AuthorizationServiceCollectionExtensions.AddAuthorization(Microsoft.Extensions.DependencyInjection.IServiceCollection)'.
```

`AuthorizationServiceCollectionExtensions.AddAuthorization` does not exist anymore in core 3.

If it is your desire to evangelize this product and allow it to be a stepping stone to convert users to paying customers of PolicyServer this library should at least work on the latest version of core.